### PR TITLE
Improve Version Management and Error Handling

### DIFF
--- a/lib/active_versioning.rb
+++ b/lib/active_versioning.rb
@@ -2,6 +2,7 @@ require 'active_versioning/version'
 require 'generators/active_versioning_generator'
 
 module ActiveVersioning
-  autoload :Events, 'active_versioning/events'
-  autoload :Model,  'active_versioning/model'
+  autoload :Events,         'active_versioning/events'
+  autoload :Model,          'active_versioning/model'
+  autoload :VersionManager, 'active_versioning/version_manager'
 end

--- a/lib/active_versioning.rb
+++ b/lib/active_versioning.rb
@@ -2,6 +2,7 @@ require 'active_versioning/version'
 require 'generators/active_versioning_generator'
 
 module ActiveVersioning
+  autoload :Errors,         'active_versioning/errors'
   autoload :Events,         'active_versioning/events'
   autoload :Model,          'active_versioning/model'
   autoload :VersionManager, 'active_versioning/version_manager'

--- a/lib/active_versioning/errors.rb
+++ b/lib/active_versioning/errors.rb
@@ -1,0 +1,8 @@
+module ActiveVersioning
+  module Errors
+    autoload :IncompatibleVersion, 'active_versioning/errors/incompatible_version'
+
+    RecordNotPersisted = Class.new(StandardError)
+    InvalidVersion     = Class.new(StandardError)
+  end
+end

--- a/lib/active_versioning/errors/incompatible_version.rb
+++ b/lib/active_versioning/errors/incompatible_version.rb
@@ -1,0 +1,12 @@
+module ActiveVersioning
+  module Errors
+    class IncompatibleVersion < StandardError
+      attr_reader :record, :version
+
+      def initialize(record, version)
+        @record  = record
+        @version = version
+      end
+    end
+  end
+end

--- a/lib/active_versioning/model.rb
+++ b/lib/active_versioning/model.rb
@@ -26,7 +26,7 @@ module ActiveVersioning
       def reify
         resource = versionable(true)
 
-        # Reload the versionable so we get a new one
+        # Necessary to ensure resource and versionable are two distinct objects in memory
         versionable(true)
 
         resource.assign_attributes(object.slice(*resource.versioned_attribute_names))

--- a/lib/active_versioning/model/version_proxy.rb
+++ b/lib/active_versioning/model/version_proxy.rb
@@ -105,7 +105,7 @@ module ActiveVersioning
       private
 
       def draft_exception
-        VersionInvalid.new("Version #{version.id} must be a draft")
+        ActiveVersioning::Errors::InvalidVersion.new("Version #{version.id} must be a draft")
       end
 
       def version_attributes

--- a/lib/active_versioning/model/versioned.rb
+++ b/lib/active_versioning/model/versioned.rb
@@ -7,7 +7,6 @@ module ActiveVersioning
 
           after_create :create_version!
 
-          # Set by controller params
           attr_accessor :version_author
         end
       end

--- a/lib/active_versioning/model/versioned.rb
+++ b/lib/active_versioning/model/versioned.rb
@@ -1,8 +1,6 @@
 module ActiveVersioning
   module Model
     module Versioned
-      RecordNotPersisted = Class.new(StandardError)
-
       def self.included(base)
         base.class_eval do
           has_many :versions, -> { newest_first }, as: :versionable, dependent: :destroy
@@ -24,7 +22,7 @@ module ActiveVersioning
 
       def current_draft(force_reload = false)
         unless persisted?
-          raise RecordNotPersisted.new("#{self} must be persisted to create a draft version")
+          raise ActiveVersioning::Errors::RecordNotPersisted.new("#{self} must be persisted to create a draft version")
         end
 
         @current_draft = nil if force_reload

--- a/lib/active_versioning/version_manager.rb
+++ b/lib/active_versioning/version_manager.rb
@@ -1,0 +1,40 @@
+module ActiveVersioning
+  class IncompatibleVersionError < StandardError
+    attr_reader :record, :version
+
+    def initialize(record, version)
+      @record  = record
+      @version = version
+    end
+  end
+
+  class VersionManager < Struct.new(:record)
+    BLACKLISTED_ATTRIBUTES = %w(
+      created_at
+      updated_at
+      published
+    )
+
+    def create_draft_from_version(id)
+      version = record.versions.find(id)
+
+      ensure_compatibility_with(version)
+
+      new_version        = record.versions.draft.first_or_create(event: 'draft')
+      new_version.object = version.object
+      new_version.save
+    end
+
+    def ensure_compatibility_with(version)
+      incompatible_attributes(version).tap do |incompatible_attrs|
+        if incompatible_attrs.any?
+          raise IncompatibleVersionError.new(record, version), "The given version contained the following attributes that are no longer compatible with the current schema: #{incompatible_attrs.to_sentence}."
+        end
+      end
+    end
+
+    def incompatible_attributes(version)
+      version.object.keys - record.attributes.keys
+    end
+  end
+end

--- a/lib/active_versioning/version_manager.rb
+++ b/lib/active_versioning/version_manager.rb
@@ -19,7 +19,7 @@ module ActiveVersioning
     def ensure_compatibility_with(version)
       incompatible_attributes(version).tap do |incompatible_attrs|
         if incompatible_attrs.any?
-          raise Errors::IncompatibleVersion.new(record, version), "The given version contained the following attributes that are no longer compatible with the current schema: #{incompatible_attrs.to_sentence}."
+          raise Errors::IncompatibleVersion.new(record, version), "The given version contains attributes that are no longer compatible with the current schema: #{incompatible_attrs.to_sentence}."
         end
       end
     end

--- a/lib/active_versioning/version_manager.rb
+++ b/lib/active_versioning/version_manager.rb
@@ -1,13 +1,4 @@
 module ActiveVersioning
-  class IncompatibleVersionError < StandardError
-    attr_reader :record, :version
-
-    def initialize(record, version)
-      @record  = record
-      @version = version
-    end
-  end
-
   class VersionManager < Struct.new(:record)
     BLACKLISTED_ATTRIBUTES = %w(
       created_at
@@ -28,7 +19,7 @@ module ActiveVersioning
     def ensure_compatibility_with(version)
       incompatible_attributes(version).tap do |incompatible_attrs|
         if incompatible_attrs.any?
-          raise IncompatibleVersionError.new(record, version), "The given version contained the following attributes that are no longer compatible with the current schema: #{incompatible_attrs.to_sentence}."
+          raise Errors::IncompatibleVersion.new(record, version), "The given version contained the following attributes that are no longer compatible with the current schema: #{incompatible_attrs.to_sentence}."
         end
       end
     end

--- a/spec/lib/active_versioning/model/version_proxy_spec.rb
+++ b/spec/lib/active_versioning/model/version_proxy_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ActiveVersioning::Model::VersionProxy do
       subject { described_class.new(post.versions.committed.first) }
 
       it "raises an error" do
-        expect { subject.commit }.to raise_error(ActiveVersioning::Model::VersionProxy::VersionInvalid)
+        expect { subject.commit }.to raise_error(ActiveVersioning::Errors::InvalidVersion)
       end
     end
   end

--- a/spec/lib/active_versioning/model/versioned_spec.rb
+++ b/spec/lib/active_versioning/model/versioned_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ActiveVersioning::Model::Versioned do
       subject { ActiveVersioning::Test::Post.new }
 
       it "raises an error" do
-        expect { subject.current_draft }.to raise_error(ActiveVersioning::Model::Versioned::RecordNotPersisted)
+        expect { subject.current_draft }.to raise_error(ActiveVersioning::Errors::RecordNotPersisted)
       end
     end
 

--- a/spec/lib/active_versioning/model/versioned_spec.rb
+++ b/spec/lib/active_versioning/model/versioned_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe ActiveVersioning::Model::Versioned do
     let!(:version) do
       subject.versions.committed.create(
         event:  ActiveVersioning::Events::COMMIT,
-        object: { title: 'Random Title', body: 'Random body text.' }
+        object: { 'title' => 'Random Title', 'body' => 'Random body text.' }
       )
     end
 

--- a/spec/lib/active_versioning/model_spec.rb
+++ b/spec/lib/active_versioning/model_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ActiveVersioning::Model do
     context "with an object containing unknown attributes" do
       let!(:version) do
         ActiveVersioning::Test::Version.create(
+          event:       'commit',
           versionable: post,
           object:      { 'title' => 'Ruh Roh', 'rating' => '4 Stars' },
         )

--- a/spec/lib/active_versioning/version_manager_spec.rb
+++ b/spec/lib/active_versioning/version_manager_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe ActiveVersioning::VersionManager do
       it "raises an error" do
         expect {
           subject.create_draft_from_version(incompatible_version.id)
-        }.to raise_error(ActiveVersioning::IncompatibleVersionError)
+        }.to raise_error(ActiveVersioning::Errors::IncompatibleVersion)
       end
 
       it "raises an error object with the original record and the offending version" do
         begin
           subject.create_draft_from_version(incompatible_version.id)
-        rescue ActiveVersioning::IncompatibleVersionError => error
+        rescue ActiveVersioning::Errors::IncompatibleVersion => error
           expect(error.message).to eq 'The given version contained the following attributes that are no longer compatible with the current schema: rating.'
           expect(error.record).to eq post
           expect(error.version).to eq incompatible_version

--- a/spec/lib/active_versioning/version_manager_spec.rb
+++ b/spec/lib/active_versioning/version_manager_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe ActiveVersioning::VersionManager do
+  let!(:post) { ActiveVersioning::Test::Post.create(title: 'So Post', body: 'Such interesting.  Very wow.') }
+
+  let!(:incompatible_version) do
+    ActiveVersioning::Test::Version.create(
+      event:       'commit',
+      versionable: post,
+      object:      { 'title' => 'Ruh Roh', 'rating' => '4 Stars' },
+    )
+  end
+
+  subject { described_class.new(post) }
+
+  describe "#create_draft_from_version" do
+    context "when there are incompatible attributes in the given version" do
+      it "raises an error" do
+        expect {
+          subject.create_draft_from_version(incompatible_version.id)
+        }.to raise_error(ActiveVersioning::IncompatibleVersionError)
+      end
+
+      it "raises an error object with the original record and the offending version" do
+        begin
+          subject.create_draft_from_version(incompatible_version.id)
+        rescue ActiveVersioning::IncompatibleVersionError => error
+          expect(error.message).to eq 'The given version contained the following attributes that are no longer compatible with the current schema: rating.'
+          expect(error.record).to eq post
+          expect(error.version).to eq incompatible_version
+        end
+      end
+    end
+  end
+
+  describe "#incompatible_attributes" do
+    it { expect(subject.incompatible_attributes(incompatible_version)).to eq ['rating'] }
+  end
+end

--- a/spec/lib/active_versioning/version_manager_spec.rb
+++ b/spec/lib/active_versioning/version_manager_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActiveVersioning::VersionManager do
         begin
           subject.create_draft_from_version(incompatible_version.id)
         rescue ActiveVersioning::Errors::IncompatibleVersion => error
-          expect(error.message).to eq 'The given version contained the following attributes that are no longer compatible with the current schema: rating.'
+          expect(error.message).to eq 'The given version contains attributes that are no longer compatible with the current schema: rating.'
           expect(error.record).to eq post
           expect(error.version).to eq incompatible_version
         end


### PR DESCRIPTION
This PR refactors a few errors to better encapsulate version management and provides some additional error handling around incompatible versions.

I'm looking for feedback/input on how best to reconcile incompatible versions.  Should users be allowed to configure whether or not an error is raised or the incompatible attributes are just ignored?