### PR TITLE
Fix migration template for Rails 5.2

### DIFF
--- a/lib/generators/active_versioning/templates/migrations/create_versions.rb
+++ b/lib/generators/active_versioning/templates/migrations/create_versions.rb
@@ -1,4 +1,9 @@
-class CreateVersions < ActiveRecord::Migration
+<%
+  parent_class = ActiveRecord::Migration
+  parent_class = parent_class[parent_class.current_version] if Rails::VERSION::MAJOR >= 5
+-%>
+
+class CreateVersions < <%= parent_class.to_s %>
   def change
     create_table :versions do |t|
       t.string   :versionable_type, null: false


### PR DESCRIPTION
Rails 5.2 requires migrations inherit from a specific version. This means that the current migration template generates invalid code.

This PR fixes it, while staying compatible with previous versions of Rails.
