### PR TITLE
Update nested attribute versioning to support has-many relationships

### DIFF
--- a/lib/active_versioning/model.rb
+++ b/lib/active_versioning/model.rb
@@ -41,11 +41,24 @@ module ActiveVersioning
       def reify_nested_attributes(resource)
         resource.versioned_nested_attribute_names.each do |relationship|
           relationship_attrs = object["#{relationship}_attributes"]
-          resource.send(
-            :assign_nested_attributes_for_one_to_one_association,
-            relationship.to_sym,
-            relationship_attrs
-          ) if relationship_attrs.present?
+
+          if relationship_attrs.present?
+            reflection = resource.association(relationship).reflection
+
+            if reflection.has_one? || reflection.belongs_to?
+              resource.send(
+                :assign_nested_attributes_for_one_to_one_association,
+                relationship.to_sym,
+                relationship_attrs
+              )
+            else
+              resource.send(
+                :assign_nested_attributes_for_collection_association,
+                relationship.to_sym,
+                relationship_attrs
+              )
+            end
+          end
         end
       end
     end

--- a/lib/active_versioning/model/version_proxy.rb
+++ b/lib/active_versioning/model/version_proxy.rb
@@ -99,7 +99,7 @@ module ActiveVersioning
 
         version.update(attrs)
 
-        __getobj__.update(versioned_attributes)
+        version.versionable.update(versioned_attributes)
       end
 
       private

--- a/lib/active_versioning/model/versioned.rb
+++ b/lib/active_versioning/model/versioned.rb
@@ -63,7 +63,9 @@ module ActiveVersioning
             nested_attrs = if reflection.belongs_to? || reflection.has_one?
               public_send(name).try(:public_send, :attributes)
             else
-              public_send(name).map { |a| a.attributes }
+              public_send(name).map do |a|
+                a.attributes.merge(_destroy: a.marked_for_destruction?)
+              end
             end
 
             if nested_attrs.present?

--- a/lib/active_versioning/model/versioned.rb
+++ b/lib/active_versioning/model/versioned.rb
@@ -57,8 +57,20 @@ module ActiveVersioning
       def nested_attributes
         versioned_nested_attribute_names.reduce(Hash.new) do |attrs, name|
           if nested_attributes_names.include?(name)
-            nested_attrs = public_send(name).try(:public_send, :attributes)
-            attrs.merge("#{name}_attributes" => nested_attrs) if nested_attrs.present?
+            nested_association = association(name)
+            reflection = nested_association.reflection
+
+            nested_attrs = if reflection.belongs_to? || reflection.has_one?
+              public_send(name).try(:public_send, :attributes)
+            else
+              public_send(name).map { |a| a.attributes }
+            end
+
+            if nested_attrs.present?
+              attrs.merge("#{name}_attributes" => nested_attrs)
+            else
+              attrs
+            end
           end
         end || {}
       end

--- a/spec/lib/active_versioning/model/versioned_spec.rb
+++ b/spec/lib/active_versioning/model/versioned_spec.rb
@@ -166,6 +166,6 @@ RSpec.describe ActiveVersioning::Model::Versioned do
   end
 
   describe "#versioned_nested_attribute_names" do
-    it { expect(subject.versioned_nested_attribute_names).to match_array %w(author) }
+    it { expect(subject.versioned_nested_attribute_names).to match_array %w(author comments) }
   end
 end

--- a/spec/lib/active_versioning/nested_attributes_spec.rb
+++ b/spec/lib/active_versioning/nested_attributes_spec.rb
@@ -98,5 +98,22 @@ RSpec.describe "assigning nested attributes" do
     }.from(["First"]).to(["First!", "Second!"])
   end
 
-  # deletes has-many relationships
+  it "deletes has-many relationships" do
+    subject.assign_attributes(comments_attributes: [{ body: "First" }])
+    subject.save
+    subject.commit
+
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+    p.assign_attributes(comments_attributes: [{ id: p.comments.first.id, _destroy: "1" }])
+    p.save
+
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+    expect {
+      p.commit
+    }.to change {
+      ActiveVersioning::Test::Comment.pluck(:body)
+    }.from(["First"]).to([])
+  end
 end

--- a/spec/lib/active_versioning/nested_attributes_spec.rb
+++ b/spec/lib/active_versioning/nested_attributes_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe ActiveVersioning::Model::Versioned do
+RSpec.describe "assigning nested attributes" do
   let!(:post) do
     ActiveVersioning::Test::Post.create(
       title: 'So Post',
@@ -10,52 +10,54 @@ RSpec.describe ActiveVersioning::Model::Versioned do
 
   let!(:committed_at) { Time.utc(2014, 11, 26, 12, 42, 35) }
 
-  describe "assigning nested attributes" do
-    let(:subject) { post.current_draft }
+  let(:subject) { post.current_draft }
 
-    it "creates a new belongs-to relationship" do
-      expect {
-        subject.assign_attributes(author_attributes: { name: "Steve" })
-        subject.save
-      }.not_to change {
-        ActiveVersioning::Test::User.count
-      }
-
-      p = ActiveVersioning::Test::Post.find(post.id).current_draft
-
-      expect { p.commit }.to change { ActiveVersioning::Test::User.count }.by(1)
-    end
-
-    it "updates an existing belongs-to relationship" do
+  it "creates a new belongs-to relationship" do
+    expect {
       subject.assign_attributes(author_attributes: { name: "Steve" })
       subject.save
-      subject.commit
+    }.not_to change {
+      ActiveVersioning::Test::User.count
+    }
 
-      p = ActiveVersioning::Test::Post.find(post.id).current_draft
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
 
-      p.assign_attributes(author_attributes: { id: p.author.id, name: "Steeve" })
-      p.save
-
-      p = ActiveVersioning::Test::Post.find(post.id).current_draft
-
-      expect {
-        p.commit
-      }.to change {
-        ActiveVersioning::Test::User.first.name
-      }.from("Steve").to("Steeve")
-    end
-
-    it "creates a new has-many relationship" do
-      expect {
-        subject.assign_attributes(comments_attributes: [{ body: "First" }, { body: "Second" }])
-        subject.save
-      }.not_to change {
-        ActiveVersioning::Test::Comment.count
-      }
-
-      p = ActiveVersioning::Test::Post.find(post.id).current_draft
-
-      expect { p.commit }.to change { ActiveVersioning::Test::Comment.count }.by(2)
-    end
+    expect { p.commit }.to change { ActiveVersioning::Test::User.count }.by(1)
   end
+
+  it "updates an existing belongs-to relationship" do
+    subject.assign_attributes(author_attributes: { name: "Steve" })
+    subject.save
+    subject.commit
+
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+    p.assign_attributes(author_attributes: { id: p.author.id, name: "Steeve" })
+    p.save
+
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+    expect {
+      p.commit
+    }.to change {
+      ActiveVersioning::Test::User.first.name
+    }.from("Steve").to("Steeve")
+  end
+
+  it "creates a new has-many relationship" do
+    expect {
+      subject.assign_attributes(comments_attributes: [{ body: "First" }, { body: "Second" }])
+      subject.save
+    }.not_to change {
+      ActiveVersioning::Test::Comment.count
+    }
+
+    p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+    expect { p.commit }.to change { ActiveVersioning::Test::Comment.count }.by(2)
+  end
+
+  # updates existing has-many relationships
+  # creates and updates has-many relationships simultaneously
+  # deletes has-many relationships
 end

--- a/spec/lib/active_versioning/nested_attributes_spec.rb
+++ b/spec/lib/active_versioning/nested_attributes_spec.rb
@@ -44,5 +44,18 @@ RSpec.describe ActiveVersioning::Model::Versioned do
         ActiveVersioning::Test::User.first.name
       }.from("Steve").to("Steeve")
     end
+
+    it "creates a new has-many relationship" do
+      expect {
+        subject.assign_attributes(comments_attributes: [{ body: "First" }, { body: "Second" }])
+        subject.save
+      }.not_to change {
+        ActiveVersioning::Test::Comment.count
+      }
+
+      p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+      expect { p.commit }.to change { ActiveVersioning::Test::Comment.count }.by(2)
+    end
   end
 end

--- a/spec/lib/active_versioning/nested_attributes_spec.rb
+++ b/spec/lib/active_versioning/nested_attributes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "assigning nested attributes" do
     ActiveVersioning::Test::Post.create(
       title: 'So Post',
       body: 'Such interesting. Very wow.'
-    ) 
+    )
   end
 
   let!(:committed_at) { Time.utc(2014, 11, 26, 12, 42, 35) }

--- a/spec/lib/active_versioning/nested_attributes_spec.rb
+++ b/spec/lib/active_versioning/nested_attributes_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe ActiveVersioning::Model::Versioned do
+  let!(:post) do
+    ActiveVersioning::Test::Post.create(
+      title: 'So Post',
+      body: 'Such interesting. Very wow.'
+    ) 
+  end
+
+  let!(:committed_at) { Time.utc(2014, 11, 26, 12, 42, 35) }
+
+  describe "assigning nested attributes" do
+    let(:subject) { post.current_draft }
+
+    it "creates a new belongs-to relationship" do
+      expect {
+        subject.assign_attributes(author_attributes: { name: "Steve" })
+        subject.save
+      }.not_to change {
+        ActiveVersioning::Test::User.count
+      }
+
+      p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+      expect { p.commit }.to change { ActiveVersioning::Test::User.count }.by(1)
+    end
+
+    it "updates an existing belongs-to relationship" do
+      subject.assign_attributes(author_attributes: { name: "Steve" })
+      subject.save
+      subject.commit
+
+      p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+      p.assign_attributes(author_attributes: { id: p.author.id, name: "Steeve" })
+      p.save
+
+      p = ActiveVersioning::Test::Post.find(post.id).current_draft
+
+      expect {
+        p.commit
+      }.to change {
+        ActiveVersioning::Test::User.first.name
+      }.from("Steve").to("Steeve")
+    end
+  end
+end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -28,6 +28,14 @@ module ActiveVersioning
           t.timestamps null: false
         end
 
+        create_table :comments do |t|
+          t.string     :author
+          t.text       :body
+          t.references :post, index: true, foreign_key: true
+
+          t.timestamps null: false
+        end
+
         create_table :versions do |t|
           t.string   :versionable_type, null: false
           t.integer  :versionable_id,   null: false

--- a/spec/support/models/comment.rb
+++ b/spec/support/models/comment.rb
@@ -1,0 +1,7 @@
+module ActiveVersioning
+  module Test
+    class Comment < ActiveRecord::Base
+      belongs_to :post
+    end
+  end
+end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -21,7 +21,7 @@ module ActiveVersioning
       end
 
       def versioned_nested_attribute_names
-        super + %w[author]
+        super + %w[author comments]
       end
     end
   end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -7,11 +7,14 @@ module ActiveVersioning
       belongs_to :author, class_name: 'User', foreign_key: 'user_id'
       belongs_to :editor, class_name: 'User', foreign_key: 'user_id'
 
+      has_many :comments
+
       validates :title,
                 :body,
                 presence: true
 
       accepts_nested_attributes_for :author
+      accepts_nested_attributes_for :comments
 
       def to_s
         title

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -14,7 +14,7 @@ module ActiveVersioning
                 presence: true
 
       accepts_nested_attributes_for :author
-      accepts_nested_attributes_for :comments
+      accepts_nested_attributes_for :comments, allow_destroy: true
 
       def to_s
         title


### PR DESCRIPTION
We were seeing issues on Shedd where nested has_many attributes for versioned models were getting lost. Bernie implemented a fix for has_one/belongs_to relationships, but it didn't work for has_many. This extends his work to support has_many.